### PR TITLE
Use LinkedHashMap for deterministic iteration order

### DIFF
--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -474,7 +474,7 @@ public class DefaultCodegen implements CodegenConfig {
      * @return map of all models indexed by names
      */
     public Map<String, CodegenModel> getAllModels(Map<String, Object> objs) {
-        Map<String, CodegenModel> allModels = new HashMap<String, CodegenModel>();
+        Map<String, CodegenModel> allModels = new LinkedHashMap<String, CodegenModel>();
         for (Entry<String, Object> entry : objs.entrySet()) {
             String modelName = toModelName(entry.getKey());
             Map<String, Object> inner = (Map<String, Object>) entry.getValue();
@@ -513,8 +513,7 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         // Let parent know about all its children
-        Map<String, CodegenModel> orderedAllModels = new LinkedHashMap<String, CodegenModel>(allModels);
-        for (String name : orderedAllModels.keySet()) {
+        for (String name : allModels.keySet()) {
             CodegenModel cm = allModels.get(name);
             CodegenModel parent = allModels.get(cm.getParent());
             // if a discriminator exists on the parent, don't add this child to the inheritance hierarchy

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -513,7 +513,8 @@ public class DefaultCodegen implements CodegenConfig {
         }
 
         // Let parent know about all its children
-        for (String name : allModels.keySet()) {
+        Map<String, CodegenModel> orderedAllModels = new LinkedHashMap<String, CodegenModel>(allModels);
+        for (String name : orderedAllModels.keySet()) {
             CodegenModel cm = allModels.get(name);
             CodegenModel parent = allModels.get(cm.getParent());
             // if a discriminator exists on the parent, don't add this child to the inheritance hierarchy

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/DefaultCodegen.java
@@ -212,7 +212,7 @@ public class DefaultCodegen implements CodegenConfig {
     // How to encode special characters like $
     // They are translated to words like "Dollar" and prefixed with '
     // Then translated back during JSON encoding and decoding
-    protected Map<String, String> specialCharReplacements = new HashMap<String, String>();
+    protected Map<String, String> specialCharReplacements = new LinkedHashMap<String, String>();
     // When a model is an alias for a simple type
     protected Map<String, String> typeAliases = null;
     protected Boolean prependFormOrBodyParameters = false;

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -703,8 +703,7 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      */
     private String sanitizeKotlinSpecificNames(final String name) {
         String word = name;
-        Map<String, String> orderedSpecialCharReplacements = new LinkedHashMap<String, String>(specialCharReplacements);
-        for (Map.Entry<String, String> specialCharacters : orderedSpecialCharReplacements.entrySet()) {
+        for (Map.Entry<String, String> specialCharacters : specialCharReplacements.entrySet()) {
             word = replaceSpecialCharacters(word, specialCharacters);
         }
 

--- a/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
+++ b/modules/openapi-generator/src/main/java/org/openapitools/codegen/languages/AbstractKotlinCodegen.java
@@ -703,7 +703,8 @@ public abstract class AbstractKotlinCodegen extends DefaultCodegen implements Co
      */
     private String sanitizeKotlinSpecificNames(final String name) {
         String word = name;
-        for (Map.Entry<String, String> specialCharacters : specialCharReplacements.entrySet()) {
+        Map<String, String> orderedSpecialCharReplacements = new LinkedHashMap<String, String>(specialCharReplacements);
+        for (Map.Entry<String, String> specialCharacters : orderedSpecialCharReplacements.entrySet()) {
             word = replaceSpecialCharacters(word, specialCharacters);
         }
 


### PR DESCRIPTION
<!-- Enter details of the change here. Include additional tests that have been done, reference to the issue for tracking, etc. -->
The tests `org.openapitools.codegen.kotlin.AbstractKotlinCodegenTest#convertModelName`, `org.openapitools.codegen.kotlin.AbstractKotlinCodegenTest#convertVarName` and `org.openapitools.codegen.DefaultCodegenTest#verifyXDiscriminatorValue` can fail due to a different iteration order of HashMap. The failures are as follows:
```
java.lang.AssertionError: expected [PonyGreaterThanEqualGreaterThanEqual] but found [PonyGreaterThanOrEqualToEqualGreaterThanOrEqualToEqual]
    at org.openapitools.codegen.kotlin.AbstractKotlinCodegenTest.convertModelName(AbstractKotlinCodegenTest.java:123)

java.lang.AssertionError: expected [ponyGreaterThanEqualGreaterThanEqual] but found [ponyGreaterThanOrEqualToEqualGreaterThanOrEqualToEqual]
    at org.openapitools.codegen.kotlin.AbstractKotlinCodegenTest.convertVarName(AbstractKotlinCodegenTest.java:136)

java.lang.AssertionError: Lists differ at element [0]: daily != sub-obj expected [daily] but found [sub-obj]
    at org.openapitools.codegen.DefaultCodegenTest.verifyXDiscriminatorValue(DefaultCodegenTest.java:1351)
```

The specification about HashMap says that "this class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time". The documentation is here for your reference: https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html

The fix is to change it to a LinkedHashMap so that the iteration order remains stable and the failure will not occur any more. In this way, the test will be more stable.
<!-- Please check the completed items below -->
### PR checklist
 
- [x] Read the [contribution guidelines](https://github.com/openapitools/openapi-generator/blob/master/CONTRIBUTING.md).
- [x] Pull Request title clearly describes the work in the pull request and Pull Request description provides details about how to validate the work. Missing information here may result in delayed response from the community.
- [x] If contributing template-only or documentation-only changes which will change sample output, [build the project](https://github.com/OpenAPITools/openapi-generator#14---build-projects) beforehand.
- [x] Run the shell script `./bin/generate-samples.sh`to update all Petstore samples related to your fix. This is important, as CI jobs will verify _all_ generator outputs of your HEAD commit as it would merge with master. These must match the expectations made by your contribution. You may regenerate an individual generator by passing the relevant config(s) as an argument to the script, for example `./bin/generate-samples.sh bin/configs/java*`. For Windows users, please run the script in [Git BASH](https://gitforwindows.org/).
- [x] File the PR against the [correct branch](https://github.com/OpenAPITools/openapi-generator/wiki/Git-Branches): `master`
- [x] Copy the [technical committee](https://github.com/openapitools/openapi-generator/#62---openapi-generator-technical-committee) to review the pull request if your PR is targeting a particular programming language.
